### PR TITLE
fix Jade path alias, prepend setting and readme.md

### DIFF
--- a/CJadeViewRenderer.php
+++ b/CJadeViewRenderer.php
@@ -53,6 +53,11 @@ class CJadeViewRenderer extends CViewRenderer
   public $viewFileExtension = '.php';
 
   /**
+   * @var string the string to be written before the compiled template. Can be set in main.php. E.g. 'prepend' => array('<?php extract((array)$data); ?>')
+   */
+  public $prepend;
+
+  /**
    * Init a Jade parser instance
    */
   public function init() {
@@ -75,7 +80,7 @@ class CJadeViewRenderer extends CViewRenderer
     } else {
       $data = file_get_contents($sourceFile);
     }
-    file_put_contents($viewFile, $data);
+    file_put_contents($viewFile, $this->prepend[0] . $data);
   }
 
   /**

--- a/CJadeViewRenderer.php
+++ b/CJadeViewRenderer.php
@@ -22,7 +22,7 @@
  * @license http://www.yiiframework.com/license/
  */
 
-Yii::setPathOfAlias('Jade', Yii::getPathOfAlias('ext.yii-jade.vendors.jade.src.Jade'));
+Yii::setPathOfAlias('Jade', dirname(__FILE__).'/vendors/jade/src/Jade');
 
 class CJadeViewRenderer extends CViewRenderer
 {

--- a/README.md
+++ b/README.md
@@ -22,5 +22,10 @@ Yii's extension for Jade template system
         ),
         ...
     ```
+* You may want to add the following line, so the compiled templates will have passed data to a template in the main var list
+
+   ```php
+            'prepend' => array('<?php extract((array)$data); ?>'),
+   ```
 
 * Jade templates must have '.jade' extension


### PR DESCRIPTION
fix Jade path alias to work not only from 'ext' subfolders
When one want to run the module not from 'ext' path. This makes the module more flexible.

having .jade templates prepared for node.js one would need to restructure data or add the prepend setting to move all data from $data object to the current var list
