### PR TITLE
Use composer and Tale Jade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/*
+*.swp
+composer.lock

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendors/jade"]
-	path = vendors/jade
-	url = git@github.com:sisoftrg/jade.php.git

--- a/CJadeViewRenderer.php
+++ b/CJadeViewRenderer.php
@@ -58,7 +58,7 @@ class CJadeViewRenderer extends CViewRenderer
   public $prepend;
 
   /**
-   * @var array the jade configuration for tale-jade, supplied to the 
+   * @var array the jade configuration for tale-jade, supplied to the
    * constructor of Renderer
    */
   public $taleJadeConfig = [];
@@ -98,22 +98,26 @@ class CJadeViewRenderer extends CViewRenderer
   // * @param boolean $return whether the rendering result should be returned
   // * @return mixed the rendering result, or null if the rendering result is not needed.
   // */
-  //public function renderFile($context,$sourceFile,$data,$return)
-  //{
-  //  $jadeSourceFile = substr($sourceFile, 0, strrpos($sourceFile, '.')).$this->fileExtension;
+  public function renderFile($context,$sourceFile,$data,$return)
+  {
+    $jadeSourceFile = substr($sourceFile, 0, strrpos($sourceFile, '.')).$this->fileExtension;
 
-  //  if(!is_file($jadeSourceFile) || ($file=realpath($jadeSourceFile))===false)
-  //    return parent::renderFile($context, $sourceFile, $data, $return);
+    if(!is_file($jadeSourceFile) || ($file=realpath($jadeSourceFile))===false)
+      return parent::renderFile($context, $sourceFile, $data, $return);
 
-  //  $viewFile = $this->getViewFile($sourceFile);
-  //  $viewFile = str_replace($this->fileExtension.($this->useRuntimePath?'':'c'), $this->viewFileExtension, $viewFile);
+    $viewFile = $this->getViewFile($sourceFile);
+    $viewFile = str_replace($this->fileExtension.($this->useRuntimePath?'':'c'), $this->viewFileExtension, $viewFile);
 
-  //  if(@filemtime($sourceFile) > @filemtime($viewFile))
-  //  {
-  //    $this->generateViewFile($sourceFile,$viewFile);
-  //    @chmod($viewFile,$this->filePermission);
-  //  }
-  //  return $context->renderInternal($viewFile,$data,$return);
-  //}
+    // Included Jade files do not cause the cache to be invalidated.
+    // By forcing a flush you can make Jade regenerate all views.
+    $forceRefresh = array_key_exists('_flush', $_GET);
+
+    if(@filemtime($sourceFile) > @filemtime($viewFile) || $forceRefresh)
+    {
+      $this->generateViewFile($sourceFile,$viewFile);
+      @chmod($viewFile,$this->filePermission);
+    }
+    return $context->renderInternal($viewFile,$data,$return);
+  }
 
 }

--- a/CJadeViewRenderer.php
+++ b/CJadeViewRenderer.php
@@ -89,15 +89,15 @@ class CJadeViewRenderer extends CViewRenderer
     file_put_contents($viewFile, $this->prepend[0] . $data);
   }
 
-  ///**
-  // * Renders a view file.
-  // * This method is required by {@link IViewRenderer}.
-  // * @param CBaseController $context the controller or widget who is rendering the view file.
-  // * @param string $sourceFile the view file path
-  // * @param mixed $data the data to be passed to the view
-  // * @param boolean $return whether the rendering result should be returned
-  // * @return mixed the rendering result, or null if the rendering result is not needed.
-  // */
+  /**
+   * Renders a view file.
+   * This method is required by {@link IViewRenderer}.
+   * @param CBaseController $context the controller or widget who is rendering the view file.
+   * @param string $sourceFile the view file path
+   * @param mixed $data the data to be passed to the view
+   * @param boolean $return whether the rendering result should be returned
+   * @return mixed the rendering result, or null if the rendering result is not needed.
+   */
   public function renderFile($context,$sourceFile,$data,$return)
   {
     $jadeSourceFile = substr($sourceFile, 0, strrpos($sourceFile, '.')).$this->fileExtension;
@@ -119,5 +119,4 @@ class CJadeViewRenderer extends CViewRenderer
     }
     return $context->renderInternal($viewFile,$data,$return);
   }
-
 }

--- a/CJadeViewRenderer.php
+++ b/CJadeViewRenderer.php
@@ -89,31 +89,31 @@ class CJadeViewRenderer extends CViewRenderer
     file_put_contents($viewFile, $this->prepend[0] . $data);
   }
 
-  /**
-   * Renders a view file.
-   * This method is required by {@link IViewRenderer}.
-   * @param CBaseController $context the controller or widget who is rendering the view file.
-   * @param string $sourceFile the view file path
-   * @param mixed $data the data to be passed to the view
-   * @param boolean $return whether the rendering result should be returned
-   * @return mixed the rendering result, or null if the rendering result is not needed.
-   */
-  public function renderFile($context,$sourceFile,$data,$return)
-  {
-    $jadeSourceFile = substr($sourceFile, 0, strrpos($sourceFile, '.')).$this->fileExtension;
+  ///**
+  // * Renders a view file.
+  // * This method is required by {@link IViewRenderer}.
+  // * @param CBaseController $context the controller or widget who is rendering the view file.
+  // * @param string $sourceFile the view file path
+  // * @param mixed $data the data to be passed to the view
+  // * @param boolean $return whether the rendering result should be returned
+  // * @return mixed the rendering result, or null if the rendering result is not needed.
+  // */
+  //public function renderFile($context,$sourceFile,$data,$return)
+  //{
+  //  $jadeSourceFile = substr($sourceFile, 0, strrpos($sourceFile, '.')).$this->fileExtension;
 
-    if(!is_file($jadeSourceFile) || ($file=realpath($jadeSourceFile))===false)
-      return parent::renderFile($context, $sourceFile, $data, $return);
+  //  if(!is_file($jadeSourceFile) || ($file=realpath($jadeSourceFile))===false)
+  //    return parent::renderFile($context, $sourceFile, $data, $return);
 
-    $viewFile = $this->getViewFile($sourceFile);
-    $viewFile = str_replace($this->fileExtension.($this->useRuntimePath?'':'c'), $this->viewFileExtension, $viewFile);
+  //  $viewFile = $this->getViewFile($sourceFile);
+  //  $viewFile = str_replace($this->fileExtension.($this->useRuntimePath?'':'c'), $this->viewFileExtension, $viewFile);
 
-    if(@filemtime($sourceFile) > @filemtime($viewFile))
-    {
-      $this->generateViewFile($sourceFile,$viewFile);
-      @chmod($viewFile,$this->filePermission);
-    }
-    return $context->renderInternal($viewFile,$data,$return);
-  }
+  //  if(@filemtime($sourceFile) > @filemtime($viewFile))
+  //  {
+  //    $this->generateViewFile($sourceFile,$viewFile);
+  //    @chmod($viewFile,$this->filePermission);
+  //  }
+  //  return $context->renderInternal($viewFile,$data,$return);
+  //}
 
 }

--- a/CJadeViewRenderer.php
+++ b/CJadeViewRenderer.php
@@ -22,7 +22,8 @@
  * @license http://www.yiiframework.com/license/
  */
 
-Yii::setPathOfAlias('Jade', dirname(__FILE__).'/vendors/jade/src/Jade');
+use Tale\Jade;
+include(dirname(__FILE__) . '/vendor/autoload');
 
 class CJadeViewRenderer extends CViewRenderer
 {
@@ -62,7 +63,7 @@ class CJadeViewRenderer extends CViewRenderer
    */
   public function init() {
     parent::init();
-    $this->jade = new Jade\Jade();
+    $this->jade = new Jade\Renderer();
   }
 
   /**

--- a/CJadeViewRenderer.php
+++ b/CJadeViewRenderer.php
@@ -23,7 +23,6 @@
  */
 
 use Tale\Jade;
-include(dirname(__FILE__) . '/vendor/autoload');
 
 class CJadeViewRenderer extends CViewRenderer
 {
@@ -59,11 +58,17 @@ class CJadeViewRenderer extends CViewRenderer
   public $prepend;
 
   /**
+   * @var array the jade configuration for tale-jade, supplied to the 
+   * constructor of Renderer
+   */
+  public $taleJadeConfig = [];
+
+  /**
    * Init a Jade parser instance
    */
   public function init() {
     parent::init();
-    $this->jade = new Jade\Renderer();
+    $this->jade = new Jade\Compiler($this->taleJadeConfig);
   }
 
   /**
@@ -77,7 +82,7 @@ class CJadeViewRenderer extends CViewRenderer
       if ($this->jade == null)
         $this->init();
 
-      $data = $this->jade->render($sourceFile);
+      $data = $this->jade->compileFile($sourceFile);
     } else {
       $data = file_get_contents($sourceFile);
     }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Note:
+-----
+__The original Jade was renamed to Pug some time ago, Talesoft has since renamed their port of Jade: TaleJade to TalePug. This wrapper still uses TaleJade, it's still here in case someone is pulling this in with composer. But you should really use [github.com/greenhost/yii-pug](github.com/greenhost/yii-pug) instead.__
+
+
+
 Yii-jade
 ========
 Yii's extension for Jade template system

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Note:
 -----
-__The original Jade was renamed to Pug some time ago, Talesoft has since renamed their port of Jade: TaleJade to TalePug. This wrapper still uses TaleJade, it's still here in case someone is pulling this in with composer. But you should really use [github.com/greenhost/yii-pug](github.com/greenhost/yii-pug) instead.__
+__The original Jade was renamed to Pug some time ago, Talesoft has since renamed their port of Jade: TaleJade to TalePug. This wrapper still uses TaleJade, it's still here in case someone is pulling this in with composer. But you should really use [github.com/greenhost/yii-pug](https://github.com/greenhost/yii-pug) instead.__
 
 
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,30 @@ Yii-jade
 Yii's extension for Jade template system
 
 ## Instructions
-* Code must be in this folder 'protected/extensions/yii-jade/'
-* Since I'm using git submodules, you need to init them:
 
-    ```bash
-    cd protected/extensions/yii-jade
-    git submodule init
-    git submodule update
+### Installation
+
+Install yii-jade with composer. Because it is not in the standard composer
+repositories, you will need to add the repository to your composer.json file as
+well:
+
     ```
-    
-* Add this to your 'config/main.php' file:
+    "repositories": [
+        {
+            "url": "https://github.com/greenhost/yii-jade",
+            "type": "vcs"
+        }
+    ]    
+    "require": {
+        "greenhost/yii-jade": "dev-dev@dev",
+    },
+
+    ```
+
+### Configuration
+
+
+To enable yii-jade, add this to your 'config/main.php' file:
     
     ```php
     'components'=>array(
@@ -22,10 +36,26 @@ Yii's extension for Jade template system
         ),
         ...
     ```
-* You may want to add the following line, so the compiled templates will have passed data to a template in the main var list
+
+You may want to add the following line, so the compiled templates will have passed data to a template in the main var list
+
 
    ```php
             'prepend' => array('<?php extract((array)$data); ?>'),
    ```
 
-* Jade templates must have '.jade' extension
+It is possible to configure other variables: check the class variables in
+`CJadeViewRenderer.php`. Each public variable can be configured in your main.php
+yii configuration file, e.g.:
+
+    ```php
+    'components'=>array(
+        ...
+        'viewRenderer'=>array(
+            'class' => 'ext.yii-jade.CJadeViewRenderer',
+            'filePermission' => '775',
+        ),
+        ...
+    ```
+
+sets the file permissions of all the files yii-jade creates to 775.

--- a/README.md
+++ b/README.md
@@ -58,4 +58,7 @@ yii configuration file, e.g.:
         ...
     ```
 
-sets the file permissions of all the files yii-jade creates to 775.
+sets the file permissions of all the files yii-jade creates to 775. Note that
+this is applied to the compiled templates with `chmod`, so this overrides the
+umask you set in PHP. Also note that this does *not* override any permissions of
+directories that are automatically created.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+	"name": "greenhost/yii-jade",
+	"description": "Fork of Yii's extension for Jade template system",
+	"license" : "New BSD License",
+	"homepage": "https://github.com/greenhost/yii-jade",
+	"require": {
+		"talesoft/tale-jade": "^1.4"
+	}
+}


### PR DESCRIPTION
Please consider pulling in our changes to use composer and the more stable Tale Jade as a back end.

We also added a flushing option, where if `$_GET['_flush']` is set, the rendered Jade template get flushed. This is a workaround for the problem that occurs when you update an included template: the including template will not be regenerated.